### PR TITLE
added space between text and image in about.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -88,7 +88,7 @@
 
            width:50%;
             margin-right: 50px;
-
+            margin-top: 30px;
             border-radius: 10px;
         }
         
@@ -102,6 +102,7 @@
         }
         .step1 img {
             max-width: 250px;
+            margin-top: 30px;
             margin-right: 50px;
             border-radius: 10px;
         }


### PR DESCRIPTION
Fixed issue: #124 

Here what I changed in this PR:-

I added an appropriate space from top side of image to maintain an equal space between text and image in about page. Now You can compare both the screenshots, before the changes and after the changes. 

Screenshot(before my work):

![Screenshot 2024-05-27 203852](https://github.com/GameSphere-MultiPlayer/Physi-c-Tech/assets/135222259/9fed88db-afeb-412d-93a0-af3e5dd21b2a)


Screenshot(after my work):

![Screenshot 2024-05-27 204011](https://github.com/GameSphere-MultiPlayer/Physi-c-Tech/assets/135222259/6c517f64-cd9f-41b6-975f-3536c12e3284)


As you can see, in the above screenshot that about page is looking more beautiful than previous.

@thevirengarg kindly review my work and merge this PR.